### PR TITLE
[Feat] 하단메뉴바컴포넌트구현

### DIFF
--- a/FrontEnd/ddogdog2/package-lock.json
+++ b/FrontEnd/ddogdog2/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ddogdog2",
       "version": "0.0.0",
       "dependencies": {
+        "@flaticon/flaticon-uicons": "^3.3.1",
         "axios": "^1.7.7",
         "bootstrap": "^5.3.3",
         "pinia": "^2.2.6",
@@ -878,6 +879,15 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@flaticon/flaticon-uicons": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@flaticon/flaticon-uicons/-/flaticon-uicons-3.3.1.tgz",
+      "integrity": "sha512-WN2zuECCdjuGBQrjzN0kpeSygzC5fgF8Q7pDR+FUuGtYWczSdIhIwoD+/fKBEfwqKfNIMZ1WouidevGQ4OJORg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "optionalDependencies": {
+        "esbuild-linux-64": "^0.14.5"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1755,6 +1765,22 @@
         "@esbuild/win32-arm64": "0.21.5",
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
+      "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/escalade": {

--- a/FrontEnd/ddogdog2/package.json
+++ b/FrontEnd/ddogdog2/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@flaticon/flaticon-uicons": "^3.3.1",
     "axios": "^1.7.7",
     "bootstrap": "^5.3.3",
     "pinia": "^2.2.6",

--- a/FrontEnd/ddogdog2/src/App.vue
+++ b/FrontEnd/ddogdog2/src/App.vue
@@ -1,22 +1,25 @@
 <template>
   <div id="app">
     <router-view />  <!-- 현재 라우트에 따라 컴포넌트를 렌더링 -->
+    <BottomNavBar />
   </div>
 </template>
 
 <script setup>
 // 필요에 따라 전역 설정이나 컴포넌트를 여기에서 추가할 수 있습니다.
+import BottomNavBar from "@/components/BottomNavBar.vue";
+
 </script>
 
 <style>
 /* 전역 스타일 설정 */
 #app {
-  font-family: Avenir, Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: #2c3e50;
-  margin-top: 60px;
+  position: relative;
+  width: 360px;
+  height: 780px;
+  margin: 0 auto;
+  background-color: #f9f9f9;
+  overflow: hidden;
 }
 /* 페이지 전체 스크롤바 숨기기 */
 body {

--- a/FrontEnd/ddogdog2/src/components/BottomNavBar.vue
+++ b/FrontEnd/ddogdog2/src/components/BottomNavBar.vue
@@ -1,0 +1,125 @@
+<!-- <template>
+  <div class="bottom-nav-bar">
+    <router-link
+      v-for="menu in menus"
+      :key="menu.name"
+      :to="menu.to"
+      class="menu-item"
+      :class="{ active: $route.path === menu.to }"
+    >
+      <i :class="menu.icon"></i>
+      <span>{{ menu.name }}</span>
+    </router-link>
+  </div>
+</template>
+
+<script setup>
+const menus = [
+  { name: "메인", to: "/", icon: "fi fi-rr-home" },
+  { name: "커뮤니티", to: "/board", icon: "fi fi-rs-comment" },
+  { name: "산책", to: "/walk", icon: "fi fi-brands-telegram" },
+  { name: "도그워커", to: "/dogwalker", icon: "fi fi-sr-paw" },
+  { name: "MY", to: "/my", icon: "fi fi-rr-user" },
+];
+</script>
+
+<style scoped>
+.router-link-active,
+.router-link-exact-active {
+  background-color: transparent !important; /* 배경색 제거 */
+}
+
+.bottom-nav-bar {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  height: 60px;
+  background-color: #fff;
+  border-top: 1px solid #ddd;
+}
+
+.menu-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-decoration: none;
+  font-size: 12px;
+  color: #000;
+}
+
+.menu-item i {
+  font-size: 20px;
+}
+
+.active {
+  color: #4BA64B;
+}
+</style> -->
+
+<template>
+  <nav class="bottom-nav">
+    <router-link
+      v-for="menu in menus"
+      :key="menu.name"
+      :to="menu.to"
+      class="menu-item"
+      :class="{ active: $route.path === menu.to }"
+    >
+      <i :class="menu.icon"></i>
+      <span>{{ menu.name }}</span>
+    </router-link>
+  </nav>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+const menus = ref([
+  { name: "Home", to: "/", icon: "fi fi-rr-home" },
+  { name: "Community", to: "/board", icon: "fi fi-rs-comment" },
+  { name: "Walk", to: "/walk", icon: "fi fi-brands-telegram" },
+  { name: "Dog Walker", to: "/dogwalker", icon: "fi fi-sr-paw" },
+  { name: "My Page", to: "/my", icon: "fi fi-rr-user" },
+]);
+</script>
+
+<style scoped>
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  display: flex;
+  justify-content: space-around; /* 메뉴 간 같은 간격 */
+  align-items: center; /* 세로 가운데 정렬 */
+  background-color: #fff; /* 메뉴바 배경색 */
+  border-top: 1px solid #ddd; /* 상단 경계선 */
+  height: 60px; /* 메뉴바 높이 */
+  z-index: 1000;
+}
+
+.menu-item {
+  flex: 1; /* 모든 메뉴가 같은 너비 */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  color: #666; /* 기본 텍스트 색상 */
+}
+
+.menu-item i {
+  font-size: 20px; /* 아이콘 크기 */
+  /* margin-bottom: 1px; 아이콘과 텍스트 간격 */
+}
+
+.menu-item span {
+  font-size: 12px; /* 텍스트 크기 */
+}
+
+.menu-item.active {
+  color: #4BA64B; /* 활성화된 메뉴 색상 */
+}
+</style>

--- a/FrontEnd/ddogdog2/src/main.js
+++ b/FrontEnd/ddogdog2/src/main.js
@@ -1,6 +1,7 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 
+import '@flaticon/flaticon-uicons/css/all/all.css';
 import App from './App.vue'
 import router from './router'
 

--- a/FrontEnd/ddogdog2/src/views/auth/LocationInputView.vue
+++ b/FrontEnd/ddogdog2/src/views/auth/LocationInputView.vue
@@ -192,8 +192,8 @@ const convertToAddress = async (lat, lng) => {
   const coord = new kakao.maps.LatLng(lat, lng);
 
   return new Promise((resolve, reject) => {
-    geocoder.coord2Address(coord.getLng(), coord.getLat(), (result, status) => {
-      // geocoder.coord2Address(127.2352, 37.64657, (result, status) => {
+    // geocoder.coord2Address(coord.getLng(), coord.getLat(), (result, status) => {
+      geocoder.coord2Address(127.2352, 37.64657, (result, status) => {
       if (status === kakao.maps.services.Status.OK) {
         const roadAddress = result[0]?.road_address?.address_name; // 도로명 주소
         const jibunAddress = result[0]?.address?.address_name; // 지번 주소


### PR DESCRIPTION
### 👀 관련 이슈

하단 메뉴바 컴포넌트 생성 및 라우팅 구현
Closes #42 

### ✨ 작업한 내용

- 하단 메뉴바 컴포넌트(`BottomNavBar.vue`) 생성
- 5개의 메뉴(Home, Community, Walk, Dog Walker, My Page) 추가
- 각 메뉴에 아이콘(`flaticon-uicons`)과 텍스트 적용
- Flexbox를 활용하여 동일한 간격 및 중앙 정렬 구현
- 선택된 메뉴의 텍스트 및 아이콘 색상을 강조(#4BA64B)
- 클릭 시 해당 페이지로 라우팅
  - Home: `/`
  - Community: `/board`
  - Walk: `/walk`
  - Dog Walker: `/dogwalker`
  - My Page: `/my`

### 💬 PR Point

- 각 메뉴의 라우팅 동작 확인
- 모바일 환경에서 메뉴바가 균일하게 표시되는지 검토

### 🍰 참고사항

- 아이콘은 `@flaticon/flaticon-uicons` 패키지를 사용하며, 패키지 설치가 필요합니다.
  ```bash
  npm i @flaticon/flaticon-uicons
