### PR TITLE
[Feat] 도그워커 페이지 탭 구조 생성

### DIFF
--- a/FrontEnd/ddogdog2/src/App.vue
+++ b/FrontEnd/ddogdog2/src/App.vue
@@ -13,10 +13,18 @@ import BottomNavBar from "@/components/BottomNavBar.vue";
 
 <style>
 /* 전역 스타일 설정 */
-#app {
+/* #app {
   position: relative;
   width: 360px;
   height: 780px;
+  margin: 0 auto;
+  background-color: #f9f9f9;
+  overflow: hidden;
+} */
+
+#app {
+  max-width: 360px;
+  height: 100vh;
   margin: 0 auto;
   background-color: #f9f9f9;
   overflow: hidden;

--- a/FrontEnd/ddogdog2/src/components/DoForMeTab.vue
+++ b/FrontEnd/ddogdog2/src/components/DoForMeTab.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+<h1>해주세요</h1>
+  </div>
+</template>
+
+<script setup>
+
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/FrontEnd/ddogdog2/src/components/DoForYouTab.vue
+++ b/FrontEnd/ddogdog2/src/components/DoForYouTab.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <h1>해드려요</h1>
+  </div>
+</template>
+
+<script setup>
+
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/FrontEnd/ddogdog2/src/components/DogWalkerTab.vue
+++ b/FrontEnd/ddogdog2/src/components/DogWalkerTab.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+<h1>DogWalkerTab</h1>
+  </div>
+</template>
+
+<script setup>
+
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/FrontEnd/ddogdog2/src/router/index.js
+++ b/FrontEnd/ddogdog2/src/router/index.js
@@ -26,6 +26,11 @@ import DogWalkerDetailView from '@/views/dogwalker/DogWalkerDetailView.vue';
 import DogWalkerListView from '@/views/dogwalker/DogWalkerListView.vue'; // 추가
 import TestView from '../views/TestView.vue';
 
+import DoForMeTab from '@/components/DoForMeTab.vue';
+import DoForYouTab from '@/components/DoForYouTab.vue'
+import DogWalkerTab from '@/components/DogWalkerTab.vue'
+import DogWalkerView from '@/views/dogwalker/DogwalkerView.vue';
+
 const routes = [
   { path: '/login', component: LoginPageView }, // 로그인 페이지
   { path: '/signup', component: SignupPageView }, // 회원가입 페이지
@@ -51,6 +56,13 @@ const routes = [
   { path: "/dog-walker-profile", component: DogWalkerProfileView }, // 도그워커 프로필 작성 페이지 
   { path: "/dogwalker/:id", component: DogWalkerDetailView }, // 특정 도그워커 상세 페이지
   { path: '/dogwalker-list', component: DogWalkerListView }, // 도그워커 리스트 페이지 추가
+
+  { path: '/dogwalker', name: 'DogWalker', component: DogWalkerView, children: [
+    { path: '', name: 'DogWalkerTab', component: DogWalkerTab },
+    { path: 'doforme', name: 'DoForMeTab', component: DoForMeTab },
+    { path: 'doforyou', name: 'DoForYouTab', component: DoForYouTab },
+    ],
+  },
 ];
 
 
@@ -78,7 +90,7 @@ router.beforeEach(async (to, from, next) => {
 
   // 메인 페이지로 이동할 때 반려견 등록 여부 확인
   
-  if (to.path === '/') {
+  if (to.path === '/login') {
     try {
       await petStore.fetchPets();
       if (petStore.pets.length === 0) {

--- a/FrontEnd/ddogdog2/src/views/dogwalker/DogwalkerView.vue
+++ b/FrontEnd/ddogdog2/src/views/dogwalker/DogwalkerView.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="dogwalker-view">
+    <nav class="tabs">
+      <button
+        v-for="tab in tabs"
+        :key="tab.name"
+        :class="{ active: activeTab === tab.name }"
+        @click="setActiveTab(tab.name)"
+      >
+        {{ tab.label }}
+      </button>
+    </nav>
+    <div class="tab-content">
+      <component :is="activeTabComponent" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from "vue";
+import DogWalkerTab from "@/components/DogWalkerTab.vue"; // '도그워커' 탭 컴포넌트
+import DoForMeTab from "@/components/DoForMeTab.vue"; // '해주세요' 탭 컴포넌트
+import DoForYouTab from "@/components/DoForYouTab.vue"; // '해드려요' 탭 컴포넌트
+
+const tabs = [
+  { name: "dogwalker", label: "도그워커", component: DogWalkerTab },
+  { name: "doforme", label: "해주세요", component: DoForMeTab },
+  { name: "doforyou", label: "해드려요", component: DoForYouTab },
+];
+
+const activeTab = ref(tabs[0].name);
+
+const activeTabComponent = computed(() => {
+  return tabs.find((tab) => tab.name === activeTab.value)?.component || null;
+});
+
+const setActiveTab = (tabName) => {
+  activeTab.value = tabName;
+};
+</script>
+
+<style scoped>
+.dogwalker-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.tabs {
+  display: flex;
+  justify-content: space-around;
+  background-color: #f9f9f9;
+  border-bottom: 1px solid #ddd;
+  padding: 10px 0;
+}
+
+.tabs button {
+  flex: 1;
+  padding: 10px 0;
+  font-size: 16px;
+  color: #999;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.tabs button.active {
+  color: #000;
+  font-weight: bold;
+  border-bottom: 2px solid #000;
+}
+
+.tab-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px;
+}
+</style>

--- a/FrontEnd/ddogdog2/src/views/walk/DataTest.vue
+++ b/FrontEnd/ddogdog2/src/views/walk/DataTest.vue
@@ -2,7 +2,7 @@
   <div>
     <h1>test</h1>
     <button @click="getData">GetData</button>
-    <p v-for="log in logs">{{ log }}</p>
+    <p v-for="log in logs" :key="log.time">{{ log }}</p>
   </div>
 </template>
 


### PR DESCRIPTION
### 👀 관련 이슈
- 도그워커 페이지의 기본 구조 및 동적 탭 기능 구현
Closes #52 

---

### ✨ 작업한 내용
- 도그워커 페이지의 초기 작업으로 탭 구성 및 동적 컴포넌트 렌더링 설정
  - `DogWalkerView.vue` 파일 생성
  - 탭 목록(`tabs`) 정의 및 동적 컴포넌트 로딩 구현
  - 선택된 탭의 시각적 구분을 위한 스타일링 추가
- 하위 컴포넌트 연결을 위한 기초 라우터 설정

---

### 💬 PR Point
- 탭 전환 시 각 컴포넌트가 정상적으로 렌더링되는지 확인이 필요합니다.
- 현재 컴포넌트 스타일링이 360x780 화면 비율에서 적절히 보이는지 검토 요망

---

### 🍰 참고사항
- `DogWalkerTab`, `DoForMeTab`, `DoForYouTab`의 세부 기능은 이후 작업에서 추가 구현 필요

---

### 📷 스크린샷 또는 GIF
| 기능 | 스크린샷 |
|:--:|:--:|
