### PR TITLE
[Feat]도그워커 '해주세요' 요청 목록 UI 구현

### DIFF
--- a/FrontEnd/ddogdog2/src/components/DoForMeTab.vue
+++ b/FrontEnd/ddogdog2/src/components/DoForMeTab.vue
@@ -1,22 +1,362 @@
-<template>
+<!-- <template>
   <div class="do-for-me-tab">
-    <h2>해주세요</h2>
-    <button @click="navigateToRequestPage">산책 해주세요</button>
+    <h2 class="section-title">내가 작성한 '해주세요'</h2>
+    <div class="my-requests">
+      <div
+        v-if="myRequests.length"
+        class="horizontal-scroll"
+      >
+        <div v-for="request in myRequests" :key="request.id" class="request-card-horizontal">
+          <h3 class="request-title">{{ request.detail }}</h3>
+          <p class="request-info">비용: <span>{{ request.cost }}원</span></p>
+          <p class="request-info">지역: <span>{{ request.region }}</span></p>
+        </div>
+      </div>
+      <div v-else class="no-data">
+        <p>아직 작성된 '해주세요'가 없습니다.</p>
+      </div>
+    </div>
+
+    <h2 class="section-title">모든 '해주세요'</h2>
+    <div class="all-requests">
+      <div v-for="request in allRequests" :key="request.id" class="request-card">
+        <h3 class="request-title">{{ request.detail }}</h3>
+        <p class="request-info">비용: <span>{{ request.cost }}원</span></p>
+        <p class="request-info">지역: <span>{{ request.region }}</span></p>
+      </div>
+    </div>
+
+    <router-link to="/dogwalker/doforme/request" class="request-button">
+      새로운 '해주세요' 작성하기
+    </router-link>
   </div>
 </template>
 
 <script setup>
-import { useRouter } from "vue-router";
+import { ref, onMounted } from "vue";
+import axios from "axios";
 
-const router = useRouter();
+const myRequests = ref([]);
+const allRequests = ref([]);
 
-const navigateToRequestPage = () => {
-  router.push("/dogwalker/doforme/request");
-};
+onMounted(async () => {
+  const userId = localStorage.getItem("user_id");
+  try {
+    const response = await axios.get("http://localhost:8081/api/trade", {
+      headers: { "access-token": localStorage.getItem("token") },
+    });
+    allRequests.value = response.data;
+    myRequests.value = response.data.filter((req) => req.superId === userId);
+  } catch (error) {
+    console.error("데이터 로드 실패:", error);
+  }
+});
 </script>
 
 <style scoped>
+/* 전체 컨테이너 */
 .do-for-me-tab {
-  padding: 16px;
+  padding: 20px;
+  font-family: Arial, sans-serif;
+  background-color: #f9f9f9;
+  min-height: 100vh;
+}
+
+/* 섹션 제목 */
+.section-title {
+  font-size: 1.2rem;
+  color: #333;
+  margin-bottom: 15px;
+}
+
+/* 가로 스크롤 섹션 */
+.my-requests {
+  margin-bottom: 30px;
+}
+
+.horizontal-scroll {
+  display: flex;
+  gap: 15px;
+  overflow-x: auto;
+  padding-bottom: 10px;
+  scrollbar-width: thin; /* Firefox */
+}
+
+.horizontal-scroll::-webkit-scrollbar {
+  height: 6px; /* 가로 스크롤바 높이 */
+}
+
+.horizontal-scroll::-webkit-scrollbar-thumb {
+  background-color: #4ba64b;
+  border-radius: 4px;
+}
+
+.horizontal-scroll::-webkit-scrollbar-track {
+  background-color: #ddd;
+}
+
+/* 가로 카드 디자인 */
+.request-card-horizontal {
+  flex: 0 0 auto;
+  width: 200px;
+  background: #ffffff;
+  padding: 15px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.request-card-horizontal h3 {
+  font-size: 0.9rem;
+  margin-bottom: 10px;
+  color: #333;
+}
+
+.request-card-horizontal p {
+  font-size: 0.8rem;
+  margin: 5px 0;
+  color: #666;
+}
+
+.request-card-horizontal .request-info span {
+  font-weight: bold;
+  color: #4ba64b;
+}
+
+/* 세로 스크롤 섹션 */
+.all-requests {
+  margin-bottom: 30px;
+}
+
+.request-card {
+  background: #ffffff;
+  padding: 15px;
+  margin-bottom: 15px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.request-card h3 {
+  font-size: 0.9rem;
+  margin-bottom: 10px;
+  color: #333;
+}
+
+.request-card p {
+  font-size: 0.8rem;
+  margin: 5px 0;
+  color: #666;
+}
+
+.request-card .request-info span {
+  font-weight: bold;
+  color: #4ba64b;
+}
+
+/* 버튼 디자인 */
+.request-button {
+  display: block;
+  text-align: center;
+  background-color: #4ba64b;
+  color: white;
+  padding: 10px;
+  border-radius: 8px;
+  text-decoration: none;
+  font-size: 1rem;
+  font-weight: bold;
+  margin-top: 20px;
+  transition: background-color 0.3s;
+}
+
+.request-button:hover {
+  background-color: #3d8e3d;
+}
+
+/* "데이터 없음" 메시지 */
+.no-data {
+  text-align: center;
+  color: #666;
+  font-size: 0.9rem;
+}
+</style> -->
+<template>
+  <div class="do-for-me-tab">
+    <h2 class="section-title">나의 '해주세요'</h2>
+    <div class="my-requests">
+      <div
+        v-if="myRequests.length"
+        class="horizontal-scroll"
+      >
+        <div v-for="request in myRequests" :key="request.id" class="request-card-horizontal">
+          <h3 class="request-title">{{ request.detail }}</h3>
+          <p class="request-info">비용: <span>{{ request.cost }}원</span></p>
+          <p class="request-info">지역: <span>{{ request.region }}</span></p>
+        </div>
+      </div>
+      <div v-else class="no-data">
+        <p>아직 작성된 '해주세요'가 없습니다.</p>
+      </div>
+    </div>
+
+    <!-- '내 반려견 산책 해주세요' 버튼 -->
+    <router-link to="/dogwalker/doforme/request" class="create-request-button">
+      내 반려견 산책 해주세요
+    </router-link>
+
+    <h2 class="section-title">실시간 '해주세요'</h2>
+    <div class="all-requests">
+      <div v-for="request in allRequests" :key="request.id" class="request-card">
+        <h3 class="request-title">{{ request.detail }}</h3>
+        <p class="request-info">비용: <span>{{ request.cost }}원</span></p>
+        <p class="request-info">지역: <span>{{ request.region }}</span></p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from "vue";
+import axios from "axios";
+
+const myRequests = ref([]);
+const allRequests = ref([]);
+
+onMounted(async () => {
+  const userId = localStorage.getItem("user_id");
+  try {
+    const response = await axios.get("http://localhost:8081/api/trade", {
+      headers: { "access-token": localStorage.getItem("token") },
+    });
+    allRequests.value = response.data;
+    myRequests.value = response.data.filter((req) => req.superId === userId);
+  } catch (error) {
+    console.error("데이터 로드 실패:", error);
+  }
+});
+</script>
+
+<style scoped>
+/* 전체 컨테이너 */
+.do-for-me-tab {
+  padding: 20px;
+  font-family: Arial, sans-serif;
+  background-color: #f9f9f9;
+  min-height: 100vh;
+}
+
+/* 섹션 제목 */
+.section-title {
+  font-size: 1.2rem;
+  color: #333;
+  margin-bottom: 15px;
+}
+
+/* 가로 스크롤 섹션 */
+.my-requests {
+  margin-bottom: 20px;
+}
+
+.horizontal-scroll {
+  display: flex;
+  gap: 15px;
+  overflow-x: auto;
+  padding-bottom: 10px;
+  scrollbar-width: thin; /* Firefox */
+}
+
+.horizontal-scroll::-webkit-scrollbar {
+  height: 6px; /* 가로 스크롤바 높이 */
+}
+
+.horizontal-scroll::-webkit-scrollbar-thumb {
+  background-color: #4ba64b;
+  border-radius: 4px;
+}
+
+.horizontal-scroll::-webkit-scrollbar-track {
+  background-color: #ddd;
+}
+
+/* 가로 카드 디자인 */
+.request-card-horizontal {
+  flex: 0 0 auto;
+  width: 200px;
+  background: #ffffff;
+  padding: 15px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.request-card-horizontal h3 {
+  font-size: 0.9rem;
+  margin-bottom: 10px;
+  color: #333;
+}
+
+.request-card-horizontal p {
+  font-size: 0.8rem;
+  margin: 5px 0;
+  color: #666;
+}
+
+.request-card-horizontal .request-info span {
+  font-weight: bold;
+  color: #4ba64b;
+}
+
+/* 세로 스크롤 섹션 */
+.all-requests {
+  margin-top: 30px;
+}
+
+.request-card {
+  background: #ffffff;
+  padding: 15px;
+  margin-bottom: 15px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.request-card h3 {
+  font-size: 0.9rem;
+  margin-bottom: 10px;
+  color: #333;
+}
+
+.request-card p {
+  font-size: 0.8rem;
+  margin: 5px 0;
+  color: #666;
+}
+
+.request-card .request-info span {
+  font-weight: bold;
+  color: #4ba64b;
+}
+
+/* '내 반려견 산책 해주세요' 버튼 */
+.create-request-button {
+  display: block;
+  text-align: center;
+  background-color: #4ba64b;
+  color: white;
+  padding: 12px;
+  border-radius: 8px;
+  text-decoration: none;
+  font-size: 1rem;
+  font-weight: bold;
+  margin-top: 20px;
+  margin-bottom: 30px;
+  transition: background-color 0.3s;
+}
+
+.create-request-button:hover {
+  background-color: #3d8e3d;
+}
+
+/* "데이터 없음" 메시지 */
+.no-data {
+  text-align: center;
+  color: #666;
+  font-size: 0.9rem;
 }
 </style>

--- a/FrontEnd/ddogdog2/src/components/DogWalkerTab.vue
+++ b/FrontEnd/ddogdog2/src/components/DogWalkerTab.vue
@@ -1,13 +1,284 @@
 <template>
-  <div>
-<h1>DogWalkerTab</h1>
+  <div class="dogwalker-tab">
+    <div class="header">
+      <button class="main-button" @click="navigateToSignup">도그워커 가입하기</button>
+    </div>
+
+    <div class="actions">
+      <button class="sub-button" @click="navigateToDoForMe">해주세요 작성하기</button>
+      <button class="sub-button" @click="navigateToDoForYou">해드려요 작성하기</button>
+    </div>
+
+    <div class="profile-list">
+      <h2>우리 동네 도그워커</h2>
+      <!-- 검색 기능 -->
+      <div class="search-bar-container">
+        <input
+          type="text"
+          v-model="searchQuery"
+          placeholder="지역명을 입력하세요 (예: 강남구)"
+          class="search-bar"
+        />
+        <button @click="filterDogWalkers" class="search-button">검색</button>
+      </div>
+
+      <!-- 내 지역만 보기 버튼 -->
+      <button
+        class="toggle-button"
+        :class="{ active: filterByRegion }"
+        @click="toggleFilterByRegion"
+      >
+        {{ filterByRegion ? "내 지역 보기: ON" : "내 지역 보기: OFF" }}
+      </button>
+
+      <!-- 도그워커 목록 -->
+      <div class="profiles">
+        <div
+          v-for="walker in filteredDogWalkers"
+          :key="walker.userId"
+          class="profile-card"
+        >
+          <img :src="walker.photo || defaultImage" alt="프로필 사진" class="profile-image" />
+          <div class="profile-info">
+            <h3>{{ walker.name }}</h3>
+            <p>{{ walker.introduce }}</p>
+            <p class="region">{{ walker.region }}</p>
+            <button class="view-profile" @click="viewProfile(walker.userId)">프로필 보기</button>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
+import { ref, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import axios from "axios";
 
+// 상태 관리
+const router = useRouter();
+const dogWalkers = ref([]);
+const filteredDogWalkers = ref([]);
+const searchQuery = ref("");
+const filterByRegion = ref(false);
+const defaultImage = "/assets/default-profile.png"; // 기본 이미지 경로
+
+// 사용자 지역 정보 (로컬스토리지에서 가져오기)
+const userRegion = localStorage.getItem("region") || "";
+
+// API 호출로 도그워커 목록 가져오기
+const fetchDogWalkers = async () => {
+  try {
+    const response = await axios.get("http://localhost:8081/api/user");
+    dogWalkers.value = response.data.filter((walker) => walker.dogWalker === true);
+    applyFilters();
+  } catch (error) {
+    console.error("도그워커 목록을 불러오지 못했습니다:", error);
+  }
+};
+
+// 필터 적용 함수
+const applyFilters = () => {
+  let results = dogWalkers.value;
+
+  // '내 지역만 보기' 활성화 시 필터링
+  if (filterByRegion.value) {
+    results = results.filter((walker) => walker.region.includes(userRegion));
+  }
+
+  // 검색어 필터링
+  if (searchQuery.value) {
+    results = results.filter((walker) =>
+      walker.region.toLowerCase().includes(searchQuery.value.toLowerCase())
+    );
+  }
+
+  filteredDogWalkers.value = results;
+};
+
+// 검색 버튼 동작
+const filterDogWalkers = () => {
+  applyFilters();
+};
+
+// '내 지역만 보기' 토글
+const toggleFilterByRegion = () => {
+  filterByRegion.value = !filterByRegion.value;
+  applyFilters();
+};
+
+// 페이지 로드 시 데이터 호출
+onMounted(() => {
+  fetchDogWalkers();
+});
+
+// 네비게이션 함수
+const navigateToSignup = () => {
+  router.push("/dog-walker-signup");
+};
+const navigateToDoForMe = () => {
+  router.push("/dogwalker/doforme/request");
+};
+const navigateToDoForYou = () => {
+  router.push("/dogwalker/doforyou");
+};
+const viewProfile = (userId) => {
+  router.push(`/dogwalker/${userId}`);
+};
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
+.dogwalker-tab {
+  width: 360px;
+  height: 780px;
+  margin: 0 auto;
+  padding: 10px;
+  background-color: #f9f9f9;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
 
+.header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.main-button {
+  padding: 15px;
+  font-size: 18px;
+  color: white;
+  background-color: #4ba64b;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  width: 100%;
+  max-width: 340px;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 20px;
+  align-items: center;
+}
+
+.sub-button {
+  padding: 12px;
+  font-size: 16px;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  width: 100%;
+  max-width: 340px;
+}
+
+.profile-list h2 {
+  font-size: 1.4rem;
+  margin-bottom: 10px;
+  color: #333;
+  text-align: center;
+}
+
+.search-bar-container {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+.search-bar {
+  flex: 1;
+  padding: 10px;
+  font-size: 14px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.search-button {
+  padding: 10px 15px;
+  font-size: 14px;
+  background-color: #4ba64b;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.toggle-button {
+  width: 100%;
+  padding: 10px;
+  font-size: 14px;
+  margin-bottom: 20px;
+  background-color: #ddd;
+  color: #555;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  text-align: center;
+}
+
+.toggle-button.active {
+  background-color: #4ba64b;
+  color: white;
+}
+
+.profiles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px;
+  justify-content: center;
+}
+
+.profile-card {
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  width: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 15px;
+}
+
+.profile-image {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-bottom: 10px;
+}
+
+.profile-info h3 {
+  font-size: 1rem;
+  margin-bottom: 8px;
+  color: #555;
+}
+
+.profile-info p {
+  font-size: 0.8rem;
+  color: #777;
+  text-align: center;
+  margin-bottom: 5px;
+}
+
+.profile-info .region {
+  font-size: 0.8rem;
+  font-weight: bold;
+  color: #333;
+}
+
+.view-profile {
+  padding: 8px 10px;
+  background-color: #4ba64b;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
 </style>


### PR DESCRIPTION
### 👀 관련 이슈

*산책요청 탭 구현* Closes #67 

### ✨ 작업한 내용

- '내가 작성한 해주세요' 요청 목록 가로 스크롤로 구현
  - 사용자의 요청만 필터링하여 표시
- '실시간 해주세요' 요청 목록 세로 스크롤로 구현
  - 모든 요청 데이터를 표시
- '내 반려견 산책 해주세요' 버튼 추가
  - 클릭 시 새로운 요청 작성 페이지로 이동
- 데이터 로드 실패 시 에러 로그 출력
- 각 요청 카드 UI 디자인 적용

### 💬 PR Point

-  '실시간 해주세요' 데이터 필터링 로직 검토 요망

### 🍰 참고사항

- 현재 API 엔드포인트는 `/api/trade`를 사용하고 있으며, `access-token`을 헤더에 포함하여 요청
- 사용자 ID는 로컬스토리지에서 가져와 요청 데이터 필터링 활용

### 📷 스크린샷 또는 GIF
| 기능                | 스크린샷               |
|--------------------|---------------------|
|해주세요|![스크린샷 2024-11-24 155026](https://github.com/user-attachments/assets/8c8a62ab-3a1d-4eb7-9839-389c4a85e1a4)|

