### PR TITLE
[Feat] 산책 결과 페이지 구현

### DIFF
--- a/FrontEnd/ddogdog2/src/components/PetIcon.vue
+++ b/FrontEnd/ddogdog2/src/components/PetIcon.vue
@@ -1,24 +1,26 @@
 <template>
-  <div class="pets-container d-flex overflow-auto">
+  <div class="pets-container d-flex overflow-auto"
+  :style="{ height: showEndTime ? '150px' : '80px' }">
     <div
-    v-for="pet in pets"
-    :key="pet.petId"
-    class="pet-item text-center me-3"
+      v-for="pet in pets"
+      :key="pet.petId"
+      class="pet-item text-center me-3"
     >
-    <div
-    class="rounded-circle mb-2 pet-image-container"
-    :class="{ 'selected': petStore.goWith.includes(pet.petId) }"
-    >
-    <img
-    :src="`http://localhost:8081/${pet.petPhoto}`"
-    alt="반려견 사진"
-    class="pet-image"
-    @click="handleImageClick(pet)"
-    />
+      <div
+        class="rounded-circle mb-2 pet-image-container"
+        :class="{ 'selected': petStore.goWith.includes(pet.petId) }"
+      >
+        <img
+          :src="`http://localhost:8081/${pet.petPhoto}`"
+          alt="반려견 사진"
+          class="pet-image"
+          @click="handleImageClick(pet)"
+        />
+      </div>
+      <!-- showEndTime가 true일 때만 endTime을 표시 -->
+      <p v-if="showEndTime" class="text-muted">{{ pet.endTime }}</p>
+    </div>
   </div>
-  <p class="text-muted">{{ pet.endTime }}</p>
-</div>
-</div>
 </template>
 
 <script setup>
@@ -28,23 +30,25 @@ import { usePetStore } from "@/stores/pet";
 
 const walkStore = useWalkStore();
 const petStore = usePetStore();
-const selectedPetId = ref(null); // ID of the selected pet
 
-
-const { onImageClick, pets } = defineProps({
+// Props
+const { onImageClick, pets, showEndTime } = defineProps({
   onImageClick: {
     type: Function,
     default: (pet) => console.log("기본 클릭 동작: ", pet),
   },
   pets: {
     type: Array,
+    required: true,
+  },
+  showEndTime: {
+    type: Boolean,
+    default: true, // 기본값으로 endTime 표시
   },
 });
 
-
-
+// 반려견 클릭 이벤트 핸들러
 const handleImageClick = (pet) => {
-  // Props로 전달된 함수 실행
   if (typeof onImageClick === "function") {
     onImageClick(pet.petId);
   } else {
@@ -55,37 +59,36 @@ const handleImageClick = (pet) => {
 onMounted(() => {
   walkStore.fetchMyWalkLogs();
   petStore.fetchPets();
-})
-
+});
 </script>
 
 <style scoped>
-
+/* 기존 스타일 그대로 유지 */
 .pets-container {
   gap: 1rem;
-  overflow-x: auto; /* 가로 스크롤 활성화 */
+  overflow-x: auto;
   padding-bottom: 0.5rem;
   height: 150px;
 }
 
 .pet-item {
-  flex: 0 0 auto; /* 가로 방향으로만 확장 */
-  width: 80px; /* 각 반려견 아이템의 고정 너비 */
-  cursor: pointer; /* 클릭 가능 표시 */
+  flex: 0 0 auto;
+  width: 80px;
+  cursor: pointer;
 }
 
 .pet-image-container {
   width: 70px;
   height: 70px;
   border-radius: 50%;
-  border: 2px solid transparent; /* 기본 테두리는 투명 */
+  border: 2px solid transparent;
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
 .pet-image-container.selected {
-  border-color: #007bff; /* 선택된 상태에서 테두리 강조 */
+  border-color: #007bff;
 }
 
 .pet-image {
@@ -96,6 +99,6 @@ onMounted(() => {
 }
 
 .pets-container::-webkit-scrollbar {
-  display: none; /* 스크롤바 숨김 */
+  display: none;
 }
 </style>

--- a/FrontEnd/ddogdog2/src/components/WalkLog.vue
+++ b/FrontEnd/ddogdog2/src/components/WalkLog.vue
@@ -2,65 +2,133 @@
     <div class="walk-log-view">
       <!-- 상단 반려견 아이콘 섹션 -->
       <div class="section">
-        <h2>산책 일지 기록</h2>
-        <div class="pet-icons">
-          <PetIcon :pets="pets" :onImageClick="handlePetClick" />
-        </div>
+        <h2 class="m-0">산책 일지</h2>
+        <!-- PetIcon에 showEndTime="false" 추가 -->
+         <h4 class="m-0">함께한 친구들</h4>
+        <PetIcon :pets="petStore.together" :onImageClick="handlePetClick" :showEndTime="false" />
       </div>
   
       <!-- 경로 지도 섹션 -->
       <div class="section">
         <h2>산책 경로</h2>
-        <div class="map-placeholder">경로 지도</div>
+        <div id="map" style="height: 350px; width: 100%;"></div>
       </div>
   
       <!-- 산책 데이터 섹션 -->
       <div class="section">
-        <div class="log-details">
-          <p>시작시간: {{ startTime }}</p>
-          <p>종료시간: {{ endTime }}</p>
-          <p>총시간: {{ totalTime }}</p>
-          <p>이동거리: {{ distance }} km</p>
-          <p>분류: {{ category }}</p>
-          <p v-if="category === '대리산책'">도그워커 ID: {{ dogWalkerId }}</p>
-          <p v-else>사용자 닉네임: {{ userNickname }}</p>
+        <div class="log-details-row">
+          <div class="log-item">
+            <h3>총 시간</h3>
+            <p>{{ formattedTime }}</p>
+          </div>
+          <div class="log-item">
+            <h3>총 거리</h3>
+            <p>{{ formattedDistance }} km</p>
+          </div>
+          <div class="log-item">
+            <h3>소비 칼로리</h3>
+            <p>{{ formattedCalories }} kcal</p>
+          </div>
         </div>
       </div>
     </div>
   </template>
   
   <script setup>
-  import { ref, onMounted } from "vue";
+  import { computed, onMounted } from "vue";
   import PetIcon from "@/components/PetIcon.vue"; // PetIcon 컴포넌트 import
+  import { usePetStore } from "@/stores/pet";
   import { useWalkStore } from "@/stores/walk";
   
+  const petStore = usePetStore();
   const walkStore = useWalkStore();
+
+  const walkData = walkStore.currentWalk;
   
-  const pets = ref([]);
-  const startTime = ref("10:00 AM");
-  const endTime = ref("11:00 AM");
-  const totalTime = ref("1시간");
-  const distance = ref(3.5); // km
-  const category = ref("대리산책"); // "대리산책" 또는 "개인산책"
-  const dogWalkerId = ref("walker123");
-  const userNickname = ref("홍길동");
+  // Props로 walkData 받기
+//   const { walkData } = defineProps({
+//     walkData: {
+//       type: Object,
+//       required: true,
+//       default: {
+//       walkPath:
+//         [
+//         { "lat": 37.500622, "lng": 127.036456, "time": "2024-11-16 08:00:00" },
+//         { "lat": 37.500430, "lng": 127.035900, "time": "2024-11-16 08:01:00" },
+//         { "lat": 37.500210, "lng": 127.035300, "time": "2024-11-16 08:02:00" },
+//         { "lat": 37.499980, "lng": 127.034700, "time": "2024-11-16 08:03:00" },
+//         { "lat": 37.499750, "lng": 127.034100, "time": "2024-11-16 08:04:00" },
+//         { "lat": 37.499520, "lng": 127.033500, "time": "2024-11-16 08:05:00" },
+//         { "lat": 37.499300, "lng": 127.032900, "time": "2024-11-16 08:06:00" },
+//         { "lat": 37.499080, "lng": 127.032300, "time": "2024-11-16 08:07:00" },
+//         { "lat": 37.498850, "lng": 127.031700, "time": "2024-11-16 08:08:00" },
+//         { "lat": 37.498620, "lng": 127.031100, "time": "2024-11-16 08:09:00" },
+//         { "lat": 37.498400, "lng": 127.030500, "time": "2024-11-16 08:10:00" },
+//         { "lat": 37.498180, "lng": 127.029900, "time": "2024-11-16 08:11:00" },
+//         { "lat": 37.497960, "lng": 127.029300, "time": "2024-11-16 08:12:00" },
+//         { "lat": 37.497780, "lng": 127.028800, "time": "2024-11-16 08:13:00" },
+//         { "lat": 37.497690, "lng": 127.028200, "time": "2024-11-16 08:14:00" },
+//         { "lat": 37.497650, "lng": 127.027700, "time": "2024-11-16 08:15:00" },
+//         { "lat": 37.497642, "lng": 127.027621, "time": "2024-11-16 08:16:00" }
+//         ],
+//         startTime: null,
+//         endTime: null,
+//         total: 0.34,
+//         dogWalking: false,
+//         userId: "",
+//         tradeId: null,
+//       },
+//     },
+//   });
   
-  const handlePetClick = (petId) => {
-    console.log("클릭한 Pet ID:", petId);
+  // 칼로리 계산 함수
+  const calculateCalories = (distanceInKm) => {
+    return Math.round(distanceInKm * 60 * 1000) / 1000; // 1km당 60kcal, 소수 셋째 자리 반올림
+  };
+  
+  // 총 시간 계산 함수
+  const calculateTotalTime = (start, end) => {
+    if (!start || !end) return "N/A";
+    const diffInSeconds = (new Date(end) - new Date(start)) / 1000;
+    const hours = Math.floor(diffInSeconds / 3600);
+    const minutes = Math.floor((diffInSeconds % 3600) / 60);
+    return `${hours}시간 ${minutes}분`;
+  };
+  
+  // 계산된 데이터
+  const formattedTime = computed(() => calculateTotalTime(walkData.startTime, walkData.endTime));
+  const formattedDistance = computed(() => walkData.total.toFixed(3));
+  const formattedCalories = computed(() => calculateCalories(walkData.total));
+  
+  // 지도 초기화
+  let map;
+  const initMap = () => {
+    const mapContainer = document.getElementById("map");
+    const mapOption = {
+      center: new kakao.maps.LatLng(37.5665, 126.9780),
+      level: 3,
+    };
+    map = new kakao.maps.Map(mapContainer, mapOption);
+  
+    if (walkData.walkPath.length > 1) {
+      const path = walkData.walkPath.map(
+        (point) => new kakao.maps.LatLng(point.lat, point.lng)
+      );
+      new kakao.maps.Polyline({
+        map,
+        path,
+        strokeWeight: 5,
+        strokeColor: "#FF0000",
+        strokeOpacity: 0.7,
+      });
+      map.setBounds(new kakao.maps.LatLngBounds().extend(path[0]).extend(path[path.length - 1]));
+    }
   };
   
   // Mount 시 데이터 로드
   onMounted(() => {
-    walkStore.fetchMyWalkLogs().then((data) => {
-      pets.value = data.pets;
-      startTime.value = data.startTime;
-      endTime.value = data.endTime;
-      totalTime.value = data.totalTime;
-      distance.value = data.distance;
-      category.value = data.category;
-      dogWalkerId.value = data.dogWalkerId;
-      userNickname.value = data.userNickname;
-    });
+    petStore.fetchPets();
+    initMap();
   });
   </script>
   
@@ -91,23 +159,51 @@
     overflow-x: auto;
   }
   
-  .map-placeholder {
-    height: 200px;
-    background-color: #e0e0e0;
+  .log-details-row {
     display: flex;
+    justify-content: space-between;
     align-items: center;
-    justify-content: center;
-    color: #666;
-    font-size: 1.2rem;
-  }
-  
-  .log-details {
     background-color: #f8f9fa;
     padding: 1rem;
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+  
+  .log-item {
+    flex: 1;
+    text-align: center;
+  }
+  
+  .log-item h3 {
+    font-size: 1rem;
+    font-weight: bold;
+    margin-bottom: 0.5rem;
+  }
+  
+  .log-item p {
     font-size: 0.9rem;
-    line-height: 1.5;
+    color: #666;
   }
   </style>
   
+
+
+// [
+//   { "lat": 37.500622, "lng": 127.036456, "time": "2024-11-16 08:00:00" },
+//   { "lat": 37.500430, "lng": 127.035900, "time": "2024-11-16 08:01:00" },
+//   { "lat": 37.500210, "lng": 127.035300, "time": "2024-11-16 08:02:00" },
+//   { "lat": 37.499980, "lng": 127.034700, "time": "2024-11-16 08:03:00" },
+//   { "lat": 37.499750, "lng": 127.034100, "time": "2024-11-16 08:04:00" },
+//   { "lat": 37.499520, "lng": 127.033500, "time": "2024-11-16 08:05:00" },
+//   { "lat": 37.499300, "lng": 127.032900, "time": "2024-11-16 08:06:00" },
+//   { "lat": 37.499080, "lng": 127.032300, "time": "2024-11-16 08:07:00" },
+//   { "lat": 37.498850, "lng": 127.031700, "time": "2024-11-16 08:08:00" },
+//   { "lat": 37.498620, "lng": 127.031100, "time": "2024-11-16 08:09:00" },
+//   { "lat": 37.498400, "lng": 127.030500, "time": "2024-11-16 08:10:00" },
+//   { "lat": 37.498180, "lng": 127.029900, "time": "2024-11-16 08:11:00" },
+//   { "lat": 37.497960, "lng": 127.029300, "time": "2024-11-16 08:12:00" },
+//   { "lat": 37.497780, "lng": 127.028800, "time": "2024-11-16 08:13:00" },
+//   { "lat": 37.497690, "lng": 127.028200, "time": "2024-11-16 08:14:00" },
+//   { "lat": 37.497650, "lng": 127.027700, "time": "2024-11-16 08:15:00" },
+//   { "lat": 37.497642, "lng": 127.027621, "time": "2024-11-16 08:16:00" }
+// ],

--- a/FrontEnd/ddogdog2/src/router/index.js
+++ b/FrontEnd/ddogdog2/src/router/index.js
@@ -17,7 +17,7 @@ import WelcomeDogRegistrationView from '../views/pet/WelcomeDogRegistrationView.
 import PetRegistrationView from '../views/pet/PetRegistrationView.vue';
 import WelcomeDogWalkerIntroView from '../views/dogwalker/WelcomeDogWalkerIntroView.vue';
 import WalkMainView from '@/views/walk/WalkMainView.vue';
-import WalkLog from '@/views/walk/WalkLog.vue';
+import WalkLog from '@/components/WalkLog.vue';
 import DataTest from '@/views/walk/DataTest.vue';
 
 import DogWalkerSignupView from '@/views/dogwalker/DogWalkerSignupView.vue'; // 추가
@@ -53,12 +53,13 @@ const routes = [
   { path: '/walk', name: 'walk', component: WalkView, children: [
     { path: '', name: 'walkMain', component: WalkMainView },
     { path: 'walking', name: 'walking', component: WalkingView },
+    { path: 'walklog', name: 'walklog', component: WalkLog},
   ]},
-  { path: '/walklog', component: WalkLog   },
+  // { path: '/walklog', component: WalkLog   },
   { path: '/walklogdata', component: DataTest},
   { path: "/dog-walker-signup", component: DogWalkerSignupView }, // 도그워커 가입 페이지 추가
   { path: "/dog-walker-profile", component: DogWalkerProfileView }, // 도그워커 프로필 작성 페이지 추가
-  { path: "/test", name: 'test', component: TestView},
+  { path: "/test", name: 'test', component: WalkLog },
   { path: '/dog-walker-intro', component: WelcomeDogWalkerIntroView }, // 웰컴 도그워커 소개 페이지
   { path: "/dog-walker-signup", component: DogWalkerSignupView }, // 도그워커 가입 페이지
   { path: "/dog-walker-profile", component: DogWalkerProfileView }, // 도그워커 프로필 작성 페이지 

--- a/FrontEnd/ddogdog2/src/views/walk/WalkingView.vue
+++ b/FrontEnd/ddogdog2/src/views/walk/WalkingView.vue
@@ -3,7 +3,7 @@
     <!-- 반려견 섹션 -->
     <section class="pets-section my-4">
       <h2 class="text-center">산책 중 반려견</h2>
-      <PetIcon :pets="petStore.together" :onImageClick="selectPet" />
+      <PetIcon :pets="petStore.together" :onImageClick="selectPet" :showEndTime="false" />
     </section>
 
     <!-- 세부 일정 작성 폼 -->
@@ -29,7 +29,7 @@
       </div>
       <div class="mb-3">
         <label for="notes" class="form-label">특이사항</label>
-        <textarea id="notes" class="form-control" rows="2" v-model="details.notes"></textarea>
+        <textarea id="notes" class="form-control" rows="4" v-model="details.notes"></textarea>
       </div>
     </div>
 
@@ -196,7 +196,7 @@ const stopTracking = async () => {
       await axios.post(apiUrl, walkData);
       petStore.goWith = [];
       // alert(`산책 데이터를 성공적으로 저장했습니다. 이동 거리: ${distance.value} km`);
-      router.replace({ name: "main" });
+      router.replace({ name: "walklog" });
     } catch (error) {
       console.error("데이터 저장 실패:", error);
       alert("산책 데이터를 저장하는 중 문제가 발생했습니다.");


### PR DESCRIPTION
### 👀 관련 이슈

*<!-- 관련 이슈를 적어주세요 -->*
Closes #72 
### ✨ 작업한 내용

*<!-- 작업한 내용을 적어주세요 -->*
1. 반려견 정보 표시
2. 경로를 카카오맵 api를 사용하여 구현
3. 경로 데이터 기반으로 산책 요약정보 표시
### 💬 PR Point

*<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->*

### 🍰 참고사항

*<!-- 참고할 사항이 있다면 적어주세요 -->*
1. 반려견 정보는 pet스토어에 together에 저장해 둔 것을 사용
2. 경로 정보는 walk스토어에 currentWalk에 저장해 둔 것을 사용
3. PetIcon component 사용시 showEndTime props를 통해 마지막 산책일을 표시하지 않을 수 있는 기능 추가
### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|산책 결과 페이지|<img width="180" alt="스크린샷 2024-11-24 오후 9 52 41" src="https://github.com/user-attachments/assets/777405de-3a7f-4e0b-88f5-3de752616a31">|