### PR TITLE
[Feat]'해주세요' 목록 페이지와 상세 페이지 개선

### DIFF
--- a/BackEnd/DDogDog/src/main/resources/application.properties
+++ b/BackEnd/DDogDog/src/main/resources/application.properties
@@ -3,8 +3,8 @@ spring.application.name=DDogDog
 # dataSource
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/final?serverTimezone=UTC
-spring.datasource.username=root
-spring.datasource.password=12341234
+spring.datasource.username=ssafy
+spring.datasource.password=ssafy
 
 # mybatis-config
 mybatis.mapper-locations=classpath:mappers/*.xml

--- a/FrontEnd/ddogdog2/src/components/DoForMeTab.vue
+++ b/FrontEnd/ddogdog2/src/components/DoForMeTab.vue
@@ -1,213 +1,78 @@
-<!-- <template>
-  <div class="do-for-me-tab">
-    <h2 class="section-title">내가 작성한 '해주세요'</h2>
-    <div class="my-requests">
-      <div
-        v-if="myRequests.length"
-        class="horizontal-scroll"
-      >
-        <div v-for="request in myRequests" :key="request.id" class="request-card-horizontal">
-          <h3 class="request-title">{{ request.detail }}</h3>
-          <p class="request-info">비용: <span>{{ request.cost }}원</span></p>
-          <p class="request-info">지역: <span>{{ request.region }}</span></p>
-        </div>
-      </div>
-      <div v-else class="no-data">
-        <p>아직 작성된 '해주세요'가 없습니다.</p>
-      </div>
-    </div>
-
-    <h2 class="section-title">모든 '해주세요'</h2>
-    <div class="all-requests">
-      <div v-for="request in allRequests" :key="request.id" class="request-card">
-        <h3 class="request-title">{{ request.detail }}</h3>
-        <p class="request-info">비용: <span>{{ request.cost }}원</span></p>
-        <p class="request-info">지역: <span>{{ request.region }}</span></p>
-      </div>
-    </div>
-
-    <router-link to="/dogwalker/doforme/request" class="request-button">
-      새로운 '해주세요' 작성하기
-    </router-link>
-  </div>
-</template>
-
-<script setup>
-import { ref, onMounted } from "vue";
-import axios from "axios";
-
-const myRequests = ref([]);
-const allRequests = ref([]);
-
-onMounted(async () => {
-  const userId = localStorage.getItem("user_id");
-  try {
-    const response = await axios.get("http://localhost:8081/api/trade", {
-      headers: { "access-token": localStorage.getItem("token") },
-    });
-    allRequests.value = response.data;
-    myRequests.value = response.data.filter((req) => req.superId === userId);
-  } catch (error) {
-    console.error("데이터 로드 실패:", error);
-  }
-});
-</script>
-
-<style scoped>
-/* 전체 컨테이너 */
-.do-for-me-tab {
-  padding: 20px;
-  font-family: Arial, sans-serif;
-  background-color: #f9f9f9;
-  min-height: 100vh;
-}
-
-/* 섹션 제목 */
-.section-title {
-  font-size: 1.2rem;
-  color: #333;
-  margin-bottom: 15px;
-}
-
-/* 가로 스크롤 섹션 */
-.my-requests {
-  margin-bottom: 30px;
-}
-
-.horizontal-scroll {
-  display: flex;
-  gap: 15px;
-  overflow-x: auto;
-  padding-bottom: 10px;
-  scrollbar-width: thin; /* Firefox */
-}
-
-.horizontal-scroll::-webkit-scrollbar {
-  height: 6px; /* 가로 스크롤바 높이 */
-}
-
-.horizontal-scroll::-webkit-scrollbar-thumb {
-  background-color: #4ba64b;
-  border-radius: 4px;
-}
-
-.horizontal-scroll::-webkit-scrollbar-track {
-  background-color: #ddd;
-}
-
-/* 가로 카드 디자인 */
-.request-card-horizontal {
-  flex: 0 0 auto;
-  width: 200px;
-  background: #ffffff;
-  padding: 15px;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.request-card-horizontal h3 {
-  font-size: 0.9rem;
-  margin-bottom: 10px;
-  color: #333;
-}
-
-.request-card-horizontal p {
-  font-size: 0.8rem;
-  margin: 5px 0;
-  color: #666;
-}
-
-.request-card-horizontal .request-info span {
-  font-weight: bold;
-  color: #4ba64b;
-}
-
-/* 세로 스크롤 섹션 */
-.all-requests {
-  margin-bottom: 30px;
-}
-
-.request-card {
-  background: #ffffff;
-  padding: 15px;
-  margin-bottom: 15px;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.request-card h3 {
-  font-size: 0.9rem;
-  margin-bottom: 10px;
-  color: #333;
-}
-
-.request-card p {
-  font-size: 0.8rem;
-  margin: 5px 0;
-  color: #666;
-}
-
-.request-card .request-info span {
-  font-weight: bold;
-  color: #4ba64b;
-}
-
-/* 버튼 디자인 */
-.request-button {
-  display: block;
-  text-align: center;
-  background-color: #4ba64b;
-  color: white;
-  padding: 10px;
-  border-radius: 8px;
-  text-decoration: none;
-  font-size: 1rem;
-  font-weight: bold;
-  margin-top: 20px;
-  transition: background-color 0.3s;
-}
-
-.request-button:hover {
-  background-color: #3d8e3d;
-}
-
-/* "데이터 없음" 메시지 */
-.no-data {
-  text-align: center;
-  color: #666;
-  font-size: 0.9rem;
-}
-</style> -->
 <template>
   <div class="do-for-me-tab">
-    <h2 class="section-title">나의 '해주세요'</h2>
-    <div class="my-requests">
-      <div
-        v-if="myRequests.length"
-        class="horizontal-scroll"
-      >
-        <div v-for="request in myRequests" :key="request.id" class="request-card-horizontal">
-          <h3 class="request-title">{{ request.detail }}</h3>
-          <p class="request-info">비용: <span>{{ request.cost }}원</span></p>
-          <p class="request-info">지역: <span>{{ request.region }}</span></p>
-        </div>
-      </div>
-      <div v-else class="no-data">
-        <p>아직 작성된 '해주세요'가 없습니다.</p>
-      </div>
+    <div class="section-header">
+      <h2 class="section-title">나의 '해주세요'</h2>
+      <router-link to="/dogwalker/doforme/request" class="create-request-button-horizontal">
+        +
+      </router-link>
     </div>
 
-    <!-- '내 반려견 산책 해주세요' 버튼 -->
-    <router-link to="/dogwalker/doforme/request" class="create-request-button">
-      내 반려견 산책 해주세요
-    </router-link>
+    <div class="my-requests horizontal-scroll">
+      <template v-if="myRequests.length > 0">
+        <div
+          v-for="trade in myRequests"
+          :key="trade.tradeId"
+          class="request-card-horizontal"
+          @click="navigateToDetail(trade.tradeId)"
+        >
+          <div class="request-header">
+            <span class="request-title">{{ trade.petNames.join(", ") }} 산책 해주세요!</span>
+            <span class="request-id">#{{ trade.tradeId }}</span>
+          </div>
+          <p class="request-date">
+            {{ formatDate(trade.tradeStartTime) }} ({{ calculateDuration(trade.tradeStartTime, trade.tradeEndTime) }})
+          </p>
+          <p class="request-tags">
+            #{{ trade.largeDog ? "대형견" : "소형견" }} #{{ trade.petNames.length }}마리 #{{ trade.region }}
+          </p>
+          <div class="request-footer">
+            <span class="request-author">{{ trade.nickname || "익명" }}</span>
+            <span class="request-cost">{{ trade.cost }}원</span>
+          </div>
+        </div>
+        <!-- '+ 버튼' -->
+        <router-link
+          to="/dogwalker/doforme/request"
+          class="create-request-button-horizontal"
+        >
+          +
+        </router-link>
+      </template>
+
+      <!-- 목록이 없을 때 대체 카드 -->
+      <router-link
+        v-else
+        to="/dogwalker/doforme/request"
+        class="request-card-horizontal create-request-card"
+      >
+        내 반려견 산책 해주세요
+      </router-link>
+    </div>
+    <!--구분선-->
+    <hr class="divider" />
 
     <h2 class="section-title">실시간 '해주세요'</h2>
     <div class="all-requests">
-      <div v-for="request in allRequests" :key="request.id" class="request-card">
-        <h3 class="request-title">{{ request.detail }}</h3>
-        <p class="request-info">비용: <span>{{ request.cost }}원</span></p>
-        <p class="request-info">지역: <span>{{ request.region }}</span></p>
+      <div
+        v-for="trade in trades"
+        :key="trade.tradeId"
+        class="request-card"
+        @click="navigateToDetail(trade.tradeId)"
+      >
+        <div class="request-header">
+          <span class="request-title">{{ trade.petNames.join(", ") }} 산책 해주세요!</span>
+          <span class="request-id">#{{ trade.tradeId }}</span>
+        </div>
+        <p class="request-date">
+          {{ formatDate(trade.tradeStartTime) }} ({{ calculateDuration(trade.tradeStartTime, trade.tradeEndTime) }})
+        </p>
+        <p class="request-tags">
+          #{{ trade.largeDog ? "대형견" : "소형견" }} #{{ trade.petNames.length }}마리 #{{ trade.region }}
+        </p>
+        <div class="request-footer">
+          <span class="request-author">{{ trade.nickname || "익명" }}</span>
+          <span class="request-cost">{{ trade.cost }}원</span>
+        </div>
       </div>
     </div>
   </div>
@@ -215,148 +80,229 @@ onMounted(async () => {
 
 <script setup>
 import { ref, onMounted } from "vue";
-import axios from "axios";
+import { useRouter } from "vue-router";
+import { useDoForMeStore } from "@/stores/doforme";
+
+const store = useDoForMeStore();
+const router = useRouter();
 
 const myRequests = ref([]);
-const allRequests = ref([]);
+const trades = store.trades;
 
-onMounted(async () => {
-  const userId = localStorage.getItem("user_id");
-  try {
-    const response = await axios.get("http://localhost:8081/api/trade", {
-      headers: { "access-token": localStorage.getItem("token") },
+// 컴포넌트 마운트 시 데이터 필터링
+onMounted(() => {
+  if (!store.trades.length) {
+    store.fetchTrades().then(() => {
+      const userId = localStorage.getItem("user_id");
+      myRequests.value = store.trades.filter((trade) => trade.superId === userId);
     });
-    allRequests.value = response.data;
-    myRequests.value = response.data.filter((req) => req.superId === userId);
-  } catch (error) {
-    console.error("데이터 로드 실패:", error);
+  } else {
+    const userId = localStorage.getItem("user_id");
+    myRequests.value = store.trades.filter((trade) => trade.superId === userId);
   }
 });
+
+// 상세 페이지로 이동
+const navigateToDetail = (tradeId) => {
+  router.push({
+    name: "DoForMeDetail",
+    params: { id: tradeId },
+  });
+};
+
+// 날짜 포맷
+const formatDate = (datetime) => {
+  const date = new Date(datetime);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(
+    2,
+    "0"
+  )} ${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+};
+
+// 기간 계산
+const calculateDuration = (start, end) => {
+  const startTime = new Date(start);
+  const endTime = new Date(end);
+  const diffMs = endTime - startTime;
+
+  const hours = Math.floor(diffMs / (1000 * 60 * 60));
+  const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+
+  if (minutes === 0) {
+    return `${hours}h`;
+  }
+  return `${hours}h ${minutes}m`;
+};
 </script>
 
 <style scoped>
-/* 전체 컨테이너 */
 .do-for-me-tab {
   padding: 20px;
   font-family: Arial, sans-serif;
   background-color: #f9f9f9;
-  min-height: 100vh;
 }
 
 /* 섹션 제목 */
 .section-title {
-  font-size: 1.2rem;
+  font-size: 1.4rem;
   color: #333;
-  margin-bottom: 15px;
+  margin-bottom: 10px;
+  margin-top: 10px;
 }
 
-/* 가로 스크롤 섹션 */
-.my-requests {
-  margin-bottom: 20px;
+/* 섹션 헤더 */
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1px;
 }
 
+/* '+ 버튼' (가로 스크롤) */
+.create-request-button-horizontal {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100px;
+  height: 80px;
+  background-color: #4ba64b;
+  color: white;
+  font-size: 1.5rem;
+  font-weight: bold;
+  border-radius: 8px;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.create-request-button-horizontal:hover {
+  background-color: #3d8e3d;
+}
+
+/* 가로 스크롤 */
 .horizontal-scroll {
   display: flex;
   gap: 15px;
   overflow-x: auto;
   padding-bottom: 10px;
-  scrollbar-width: thin; /* Firefox */
 }
 
-.horizontal-scroll::-webkit-scrollbar {
-  height: 6px; /* 가로 스크롤바 높이 */
-}
-
-.horizontal-scroll::-webkit-scrollbar-thumb {
-  background-color: #4ba64b;
-  border-radius: 4px;
-}
-
-.horizontal-scroll::-webkit-scrollbar-track {
-  background-color: #ddd;
-}
-
-/* 가로 카드 디자인 */
+/* 요청 카드 */
 .request-card-horizontal {
   flex: 0 0 auto;
-  width: 200px;
+  width: 300px;
   background: #ffffff;
   padding: 15px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: transform 0.2s;
+  margin-bottom: 5px;
 }
 
-.request-card-horizontal h3 {
-  font-size: 0.9rem;
-  margin-bottom: 10px;
-  color: #333;
+.request-card-horizontal:hover {
+  transform: scale(1.05);
 }
 
-.request-card-horizontal p {
-  font-size: 0.8rem;
-  margin: 5px 0;
-  color: #666;
-}
-
-.request-card-horizontal .request-info span {
+/* 요청 카드 대체 버튼 */
+.create-request-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
   font-weight: bold;
-  color: #4ba64b;
+  background-color: #4ba64b;
+  color: white;
+  text-align: center;
+  text-decoration: none;
 }
 
-/* 세로 스크롤 섹션 */
-.all-requests {
-  margin-top: 30px;
-}
-
+/* 요청 카드 (세로) */
 .request-card {
   background: #ffffff;
   padding: 15px;
   margin-bottom: 15px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: transform 0.2s;
 }
 
-.request-card h3 {
-  font-size: 0.9rem;
+.request-card:hover {
+  transform: scale(1.05);
+}
+
+.request-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   margin-bottom: 10px;
-  color: #333;
 }
 
-.request-card p {
-  font-size: 0.8rem;
-  margin: 5px 0;
+.request-title {
+  font-size: 1rem;
+  font-weight: bold;
+}
+
+.request-id {
+  font-size: 0.9rem;
+  color: #999;
+}
+
+.request-date {
+  font-size: 0.9rem;
   color: #666;
+  margin: 5px 0;
 }
 
-.request-card .request-info span {
+.request-tags {
+  font-size: 0.8rem;
+  color: #666;
+  margin-bottom: 10px;
+}
+
+.request-footer {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 10px;
+}
+
+.request-author {
+  font-size: 0.8rem;
+  color: #999;
+}
+
+.request-cost {
+  font-size: 0.9rem;
   font-weight: bold;
   color: #4ba64b;
 }
 
-/* '내 반려견 산책 해주세요' 버튼 */
-.create-request-button {
-  display: block;
-  text-align: center;
+.create-request-button-horizontal {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 30px;
+  height: 30px;
   background-color: #4ba64b;
   color: white;
-  padding: 12px;
-  border-radius: 8px;
-  text-decoration: none;
-  font-size: 1rem;
+  font-size: 1.5rem;
   font-weight: bold;
-  margin-top: 20px;
-  margin-bottom: 30px;
+  border-radius: 50%;
+  text-decoration: none;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: background-color 0.3s;
 }
 
-.create-request-button:hover {
+.create-request-button-horizontal:hover {
   background-color: #3d8e3d;
 }
 
-/* "데이터 없음" 메시지 */
-.no-data {
-  text-align: center;
-  color: #666;
-  font-size: 0.9rem;
+/* 구분선 스타일 */
+.divider { /* 추가된 부분 */
+  border: none;
+  border-top: 1px solid #ddd;
+  margin: 20px 0;
 }
+
 </style>

--- a/FrontEnd/ddogdog2/src/router/index.js
+++ b/FrontEnd/ddogdog2/src/router/index.js
@@ -34,6 +34,7 @@ import DogWalkerTab from '@/components/DogWalkerTab.vue'
 import DogWalkerView from '@/views/dogwalker/DogwalkerView.vue';
 
 import DoForMeRequestView from '@/views/dogwalker/DoForMeRequestView.vue';
+import DoForMeDetailView from '@/views/dogwalker/DoForMeDetailView.vue'; // 상세 페이지 컴포넌트 추가
 
 
 const routes = [
@@ -73,6 +74,7 @@ const routes = [
   },
 
   {path: '/dogwalker/doforme/request', name: 'DoForMeRequest', component: DoForMeRequestView},
+  { path: '/doforme/:id', name: 'DoForMeDetail', component: DoForMeDetailView, props: true }, // 해주세요 상세 페이지 라우트 추가
   
 ];
 

--- a/FrontEnd/ddogdog2/src/stores/doforme.js
+++ b/FrontEnd/ddogdog2/src/stores/doforme.js
@@ -1,0 +1,20 @@
+import { defineStore } from "pinia";
+import axios from "axios";
+
+export const useDoForMeStore = defineStore("doforme", {
+  state: () => ({
+    trades: [], // '해주세요' 거래 데이터
+  }),
+  actions: {
+    async fetchTrades() {
+      try {
+        const response = await axios.get("http://localhost:8081/api/trade/please", {
+          headers: { "access-token": localStorage.getItem("token") },
+        });
+        this.trades = response.data;
+      } catch (error) {
+        console.error("거래 데이터를 가져오는 데 실패했습니다:", error);
+      }
+    },
+  },
+});

--- a/FrontEnd/ddogdog2/src/views/dogwalker/DoForMeDetailView.vue
+++ b/FrontEnd/ddogdog2/src/views/dogwalker/DoForMeDetailView.vue
@@ -1,0 +1,175 @@
+<template>
+  <div class="doforme-detail" v-if="trade">
+    <!-- 제목 -->
+    <h1 class="title">
+      [{{ trade.tradeId }}] {{ trade.petNames?.join(", ") || "반려견 정보 없음" }} 산책 해주세요!
+    </h1>
+
+    <!-- 거래 정보 -->
+    <div class="info-section">
+      <p><strong>작성자:</strong> {{ trade.nickname || "익명" }} ({{ trade.superId }})</p>
+      <p><strong>지역:</strong> {{ trade.region }}</p>
+      <p><strong>시작 시간:</strong> {{ formatDate(trade.tradeStartTime) }}</p>
+      <p><strong>종료 시간:</strong> {{ formatDate(trade.tradeEndTime) }}</p>
+      <p><strong>금액:</strong> {{ trade.cost }}원</p>
+      <p><strong>요청 사항:</strong> {{ trade.detail }}</p>
+      <p><strong>대형견 여부:</strong> {{ trade.largeDog ? "있음" : "없음" }}</p>
+      <p><strong>상태:</strong> {{ trade.state === 0 ? "대기 중" : "완료" }}</p>
+    </div>
+
+    <!-- 반려견 정보 -->
+    <div class="pet-section" v-if="pets.length">
+      <h2>함께 가는 반려견</h2>
+      <div v-for="(pet, index) in pets" :key="pet.petId" class="pet-card">
+        <!-- 반려견 이름 버튼 -->
+        <button class="pet-name-button" @click="togglePetDetail(index)">
+          {{ pet.name }}
+        </button>
+        <!-- 반려견 상세 정보 -->
+        <div class="pet-detail">
+          <img :src="`http://localhost:8081/${pet.petPhoto}` || '/images/default-pet.jpg'" alt="반려견 프로필" class="pet-photo" />
+          <p><strong>이름:</strong> {{ pet.petName }}</p>
+          <p><strong>나이:</strong> {{ pet.petBirth }}살</p>
+          <p><strong>성별:</strong> {{ pet.petGender }}</p>
+          <p><strong>견종:</strong> {{ pet.petBreed }}</p>
+          <p><strong>체급:</strong> {{ pet.petGroup }}</p>
+          <p><strong>체중:</strong> {{ pet.petWeight }}kg</p>
+          <p><strong>특이사항:</strong> {{ pet.ps || "없음" }}</p>
+        </div>
+      </div>
+    </div>
+    <div v-else>
+      <p>함께 가는 반려견 정보가 없습니다.</p>
+    </div>
+  </div>
+
+  <!-- 로딩 상태 -->
+  <div v-else>
+    <p>데이터를 불러오는 중입니다...</p>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from "vue";
+import { useRoute } from "vue-router";
+import axios from "axios";
+
+const trade = ref(null); // 거래 상세 데이터
+const pets = ref([]); // 반려견 정보
+const showPetDetails = ref([]); // 반려견 프로필 박스 활성화 상태
+const route = useRoute(); // 라우터 정보 접근
+
+// 거래 및 반려견 정보 로드
+onMounted(async () => {
+  try {
+    // 거래 데이터 로드
+    const response = await axios.get(`http://localhost:8081/api/trade/${route.params.id}`);
+    trade.value = response.data;
+
+    // 반려견 데이터 로드
+    const petResponse = await axios.get(`http://localhost:8081/api/trade/pets/${route.params.id}`);
+    pets.value = petResponse.data;
+    console.log(pets.value[0].petPhoto)
+
+    // 반려견 프로필 활성화 초기값 설정
+    showPetDetails.value = pets.value.map(() => true);
+  } catch (error) {
+    console.error("데이터를 가져오는 데 실패했습니다:", error);
+  }
+});
+
+// 반려견 프로필 토글
+const togglePetDetail = (index) => {
+  showPetDetails.value[index] = !showPetDetails.value[index];
+};
+
+// 날짜 포맷 함수
+const formatDate = (datetime) => {
+  const date = new Date(datetime);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(
+    2,
+    "0"
+  )} ${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+};
+</script>
+
+<style scoped>
+.doforme-detail {
+  padding: 20px;
+  font-family: Arial, sans-serif;
+  background-color: #f9f9f9;
+  min-height: 100vh;
+}
+
+/* 제목 스타일 */
+.title {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 20px;
+  color: #333;
+}
+
+/* 정보 섹션 스타일 */
+.info-section p {
+  font-size: 1rem;
+  margin: 10px 0;
+  color: #555;
+}
+
+/* 반려견 섹션 스타일 */
+.pet-section {
+  margin-top: 30px;
+}
+
+.pet-section h2 {
+  font-size: 1.2rem;
+  margin-bottom: 15px;
+  color: #333;
+}
+
+/* 반려견 카드 */
+.pet-card {
+  margin-bottom: 20px;
+}
+
+.pet-name-button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background-color: #4ba64b;
+  color: white;
+  padding: 10px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 1rem;
+  margin-bottom: 10px;
+  transition: background-color 0.3s;
+}
+
+.pet-name-button:hover {
+  background-color: #3d8e3d;
+}
+
+.pet-detail {
+  padding: 10px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.pet-photo {
+  width: 100%;
+  max-height: 150px;
+  object-fit: cover;
+  border-radius: 5px;
+  margin-bottom: 10px;
+}
+
+.pet-detail p {
+  font-size: 0.9rem;
+  margin: 5px 0;
+  color: #555;
+}
+</style>


### PR DESCRIPTION
### 👀 관련 이슈
Closes #74 

### ✨ 작업한 내용
- '해주세요' 목록 페이지 개선
  - 거래 번호, 반려견 수, 작성자 닉네임 등 상세 정보 표시.
  - `+` 버튼으로 '해 주세요' 작성 페이지 연결.
  - Pinia 상태 관리(store) 연동.
- '해주세요' 상세 페이지 개선:
  - 거래 번호, 지역, 금액, 요청 사항, 상태 등 상세 정보 표시.
  - 반려견 이름 버튼을 클릭 시 프로필 정보 표시 기능 추가.
- 사용자 맞춤형 UI:
  - '나의 해주세요'와 '실시간 해주세요'를 구분하여 표시.
  - 로컬스토리지의 `user_id`를 활용한 데이터 필터링.

### 💬 PR Point
- 전체적인 코드 스타일 및 UI 디자인 점검.

### 🍰 참고사항

### 📷 스크린샷 또는 GIF
| 기능                  | 스크린샷           |
|-----------------------|--------------------|
| '나의 해주세요' 목록  | ![스크린샷 2024-11-24 214232](https://github.com/user-attachments/assets/b3af1d82-30c8-4d2b-a4ee-27b640948eb8) |
